### PR TITLE
Solution to the prints of the trailing spaces and implementation of a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# CMake build directory
+build/
+
+# Visual Studio Code workspace settings folder
+.vscode/
+
+# macOS specific files
+.DS_Store
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CXX := g++
+CXXFLAGS := -Wall -Werror -Wextra -pedantic -std=c++23 -march=native -O3
+
+TARGET := encryptor
+
+SRC := src/mainexample.cpp src/MatrixEncryptor.cpp
+OBJ := $(SRC:.cpp=.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(OBJ) $(TARGET)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,34 @@ This project implements a text encryption and decryption system using a matrix-b
 
 Clone the repository and copy the library your local project folder then include `MatrixEncryptor.h`. After that you need to implement [Eigen](https://gitlab.com/libeigen/eigen) to your project. From the given link, only the folder Eigen is required. After putting it to your project folder, from your Project's Property Pages, `C/C++ -> General -> Additional Include Directories` add Eigen folder's path.
 
+## Getting started
+
+### Prerequisites
+Before getting started with **Text Encryption With Linear Algebra**, ensure that you have the following dependencies installed on your Linux system:
+- **g++ compiler**
+- [**Eigen library**](https://eigen.tuxfamily.org/index.php?title=Main_Page)
+
+### Installation
+To use the **Text Encryption With Linear Algebra**, follow these steps:
+
+1. Clone this repository
+```Bash
+git clone git@github.com:farukalpay/TextEncryptionWithLinearAlgebra.git
+```
+2. Clone the repository of Eigen Library:
+```Bash
+git clone https://gitlab.com/libeigen/eigen
+```
+3. Go inside the directory of Eigen Library and copy the directory Eigen into this repository
+```Bash
+cp -r <path-to-Eigen-directory> <path-to-this-repo>
+```
+4. Use the Makefile to compile with make
+```Bash
+make
+```
+5. Now you should see the executable in the directory of **Text Encryption With Linear Algebra** 
+
 ## Explanation of the Algorithm
 
 ### Convert Input String to ASCII Integer

--- a/src/MatrixEncryptor.cpp
+++ b/src/MatrixEncryptor.cpp
@@ -3,6 +3,14 @@
 #include <iostream>
 #include <sstream>
 
+namespace {
+    inline void removeLastASCIISpaces(std::vector<int>& data) {
+        while (!data.empty() && data.back() == ' ') {
+            data.pop_back();
+        }
+    }
+}
+
 Eigen::MatrixXd MatrixEncryptor::generateRandomKey(int size) {
     Eigen::MatrixXd key(size, size);
     std::random_device rd;
@@ -31,7 +39,7 @@ std::vector<int> MatrixEncryptor::encrypt(const std::vector<int>& message) const
     paddedMessage.insert(paddedMessage.end(), remainder, ' '); // Padding message with spaces to make its size a multiple of the key matrix size
 
     std::vector<int> encrypted_message;
-    for (int i = 0; i < paddedMessage.size(); i += size) {
+    for (size_t i = 0; i < paddedMessage.size(); i += size) {
         Eigen::VectorXd messageVector(size);
         for (int j = 0; j < size; ++j) {
             messageVector(j) = paddedMessage[i + j];
@@ -46,7 +54,7 @@ std::vector<int> MatrixEncryptor::encrypt(const std::vector<int>& message) const
 
 std::vector<int> MatrixEncryptor::decrypt(const std::vector<int>& encrypted_message, int size) const {
     std::vector<int> decrypted_message;
-    for (int i = 0; i < encrypted_message.size(); i += size) {
+    for (size_t i = 0; i < encrypted_message.size(); i += size) {
         Eigen::VectorXd encryptedVector(size);
         for (int j = 0; j < size; ++j) {
             encryptedVector(j) = encrypted_message[i + j];
@@ -59,6 +67,7 @@ std::vector<int> MatrixEncryptor::decrypt(const std::vector<int>& encrypted_mess
             decrypted_message.push_back(decrypted_value);
         }
     }
+    removeLastASCIISpaces(decrypted_message);
     return decrypted_message;
 }
 

--- a/src/MatrixEncryptor.h
+++ b/src/MatrixEncryptor.h
@@ -1,7 +1,7 @@
 #ifndef MATRIXENCRYPTOR_H
 #define MATRIXENCRYPTOR_H
 
-#include <Eigen/Dense>
+#include "../Eigen/Dense"
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
This pull request addresses a few issues and improvements in the codebase:

**Trimming Trailing Spaces in Decrypted Message:**
I've modified the code to remove trailing spaces that appear when decrypting messages. This ensures that decrypted messages are displayed without any unintended whitespace.

**Adding Makefile for Improved Compilation:**
I've added a Makefile to streamline the compilation process. This makes it easier for developers to compile the project without needing to remember complex commands or configurations.

**Correcting Variable Types for Comparison:**
Several variables used in loops were updated to size_t to ensure correct comparison. This helps prevent potential issues related to variable overflow or incorrect comparisons.

**Adding .gitignore File:**
I've included a .gitignore file to specify which files and directories should be ignored by Git. This helps keep the repository clean by excluding unnecessary files and build artifacts.

Changes Made:

1. Removed trailing spaces in decrypted messages.
2. Added Makefile for easier compilation.
3. Updated variable types to size_t for correct comparisons.
4. Added .gitignore file.

Additional Notes:
Feel free to review the changes and provide any feedback or suggestions for improvement. Thanks for considering this pull request!
